### PR TITLE
fix: replace removed DEFAULT_SOURCE_ID with correct 'memory' source_id

### DIFF
--- a/examples/agent_summarization.py
+++ b/examples/agent_summarization.py
@@ -183,7 +183,7 @@ class SummarizationMiddleware(AgentMiddleware):
 
         # Before the agent runs: check if we should compact the history
         if session and self.context_tokens > self.token_threshold:
-            history = session.state.get(InMemoryHistoryProvider.DEFAULT_SOURCE_ID, {}).get("messages", [])
+            history = session.state.get("memory", {}).get("messages", [])
             if len(history) > 2:
                 logger.info(
                     "[📝 Summarization] Token usage (%d) exceeds threshold (%d). "
@@ -201,7 +201,7 @@ class SummarizationMiddleware(AgentMiddleware):
                 )
 
                 # Replace session history with a single summary message
-                session.state[InMemoryHistoryProvider.DEFAULT_SOURCE_ID]["messages"] = [
+                session.state["memory"]["messages"] = [
                     Message(role="assistant", text=f"[Summary of earlier conversation]\n{summary_text}"),
                 ]
 

--- a/examples/spanish/agent_summarization.py
+++ b/examples/spanish/agent_summarization.py
@@ -182,7 +182,7 @@ class SummarizationMiddleware(AgentMiddleware):
 
         # Antes de ejecutar el agente: revisar si hay que compactar el historial
         if session and self.context_tokens > self.token_threshold:
-            history = session.state.get(InMemoryHistoryProvider.DEFAULT_SOURCE_ID, {}).get("messages", [])
+            history = session.state.get("memory", {}).get("messages", [])
             if len(history) > 2:
                 logger.info(
                     "[📝 Resumen] Uso de tokens (%d) excede el umbral (%d). "
@@ -200,7 +200,7 @@ class SummarizationMiddleware(AgentMiddleware):
                 )
 
                 # Reemplazar el historial de la sesión con un único mensaje de resumen
-                session.state[InMemoryHistoryProvider.DEFAULT_SOURCE_ID]["messages"] = [
+                session.state["memory"]["messages"] = [
                     Message(role="assistant", text=f"[Resumen de la conversación anterior]\n{summary_text}"),
                 ]
 


### PR DESCRIPTION
fix: replace removed DEFAULT_SOURCE_ID with correct 'memory' source_id

`InMemoryHistoryProvider.DEFAULT_SOURCE_ID` was removed in the version of MAF pinned in pyproject.toml (fc9c81b). The auto-injected provider uses `source_id='memory'`, so replace the class attribute references with that string directly.

Affects both the English and Spanish versions of `agent_summarization.py`.

## Purpose
* Fix a runtime `AttributeError` crash in `agent_summarization.py` that occurs on the second user message. The `SummarizationMiddleware` was reading history from session state using `InMemoryHistoryProvider.DEFAULT_SOURCE_ID`, which no longer exists in the pinned MAF commit (`fc9c81b`). At that commit, the auto-injected `InMemoryHistoryProvider` uses `source_id="memory"`, so the state key is `"memory"`.

## Does this introduce a breaking change?
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
