### PR TITLE
Improve console output for handoff and magentic workflows

### DIFF
--- a/examples/spanish/workflow_handoffbuilder.py
+++ b/examples/spanish/workflow_handoffbuilder.py
@@ -26,12 +26,10 @@ from agent_framework.openai import OpenAIChatClient
 from agent_framework.orchestrations import HandoffBuilder
 from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
-from rich.logging import RichHandler
+from rich.console import Console
 
-log_handler = RichHandler(show_path=False, rich_tracebacks=True, show_level=False)
-logging.basicConfig(level=logging.WARNING, handlers=[log_handler], force=True, format="%(message)s")
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logging.basicConfig(level=logging.WARNING)
+console = Console()
 
 load_dotenv(override=True)
 API_HOST = os.getenv("API_HOST", "github")
@@ -136,19 +134,21 @@ async def main() -> None:
         # ── Ejecuta ──────────────────────────────────────────────────────
 
         prompt = "Escribe un post de LinkedIn sobre desplegar agentes Python en Azure Container Apps."
-        logger.info("Prompt: %s\n", prompt)
+        console.print(f"[bold]Prompt:[/bold] {prompt}\n")
 
         current_agent = None
 
         async for event in workflow.run(prompt, stream=True):
             if event.type == "handoff_sent":
-                logger.info("\n[Handoff] %s -> %s\n", event.data.source, event.data.target)
+                console.print(
+                    f"\n🔀 [bold yellow]Handoff:[/bold yellow] {event.data.source} → {event.data.target}\n"
+                )
 
             elif event.type == "output" and isinstance(event.data, AgentResponseUpdate):
                 if event.executor_id != current_agent:
                     current_agent = event.executor_id
-                    print(f"\n--- {current_agent} ---")
-                print(event.data.text, end="", flush=True)
+                    console.print(f"\n🤖 [bold cyan]{current_agent}[/bold cyan]")
+                console.print(event.data.text, end="")
 
     if async_credential:
         await async_credential.close()

--- a/examples/spanish/workflow_handoffbuilder_rules.py
+++ b/examples/spanish/workflow_handoffbuilder_rules.py
@@ -23,17 +23,17 @@ import logging
 import os
 import sys
 
-from agent_framework import Agent
+from pydantic import Field
+
+from agent_framework import Agent, AgentResponseUpdate, tool
 from agent_framework.openai import OpenAIChatClient
 from agent_framework.orchestrations import HandoffBuilder
 from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
-from rich.logging import RichHandler
+from rich.console import Console
 
-log_handler = RichHandler(show_path=False, rich_tracebacks=True, show_level=False)
-logging.basicConfig(level=logging.WARNING, handlers=[log_handler], force=True, format="%(message)s")
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logging.basicConfig(level=logging.WARNING)
+console = Console()
 
 load_dotenv(override=True)
 API_HOST = os.getenv("API_HOST", "github")
@@ -60,16 +60,46 @@ else:
     )
 
 
+# ── Herramientas ────────────────────────────────────────────────────────────
+
+
+@tool
+def initiate_return(
+    order_id: str = Field(description="The order ID to return"),
+    reason: str = Field(description="Reason for the return"),
+) -> str:
+    """Inicia una devolución de producto y genera una etiqueta de envío prepagada."""
+    return (
+        f"Devolución iniciada para el pedido {order_id} (motivo: {reason}). "
+        f"La etiqueta de devolución RL-{order_id}-2026 fue enviada por correo al cliente. "
+        "Por favor, deja el paquete en cualquier punto de envío dentro de 14 días."
+    )
+
+
+@tool
+def process_refund(
+    order_id: str = Field(description="The order ID to refund"),
+    amount: str = Field(description="Refund amount in USD"),
+) -> str:
+    """Procesa un reembolso al método de pago original del cliente."""
+    return (
+        f"Reembolso de ${amount} para el pedido {order_id} procesado. "
+        "Aparecerá en el método de pago original en 5-10 días hábiles. "
+        f"Número de confirmación: RF-{order_id}-2026."
+    )
+
+
 # ── Agentes ───────────────────────────────────────────────────────────────
 
 triage_agent = Agent(
     client=client,
     name="agente_triaje",
     instructions=(
-        "Eres un agente de triage de soporte al cliente. Saluda al cliente, entiende su problema "
-        "y haz handoff al especialista correcto: agente_pedidos para temas de pedidos y "
+        "Eres un agente de triage de soporte al cliente. Reconoce brevemente el problema del cliente "
+        "y haz handoff de inmediato al especialista correcto: agente_pedidos para temas de pedidos, "
         "agente_devoluciones para devoluciones. No puedes gestionar reembolsos directamente. "
-        "Cuando el caso esté resuelto, di 'Goodbye!' (Goodbye/Adiós) para terminar la sesión."
+        "NO pidas detalles adicionales al cliente — el especialista se encargará. "
+        "Cuando el caso esté resuelto, di '¡Adiós!' para terminar la sesión."
     ),
 )
 
@@ -86,19 +116,24 @@ return_agent = Agent(
     client=client,
     name="agente_devoluciones",
     instructions=(
-        "Atiendes devoluciones de productos. Ayuda al cliente a iniciar una devolución. "
-        "Si también quiere un reembolso, haz handoff a agente_reembolsos. "
+        "Atiendes devoluciones de productos. Usa la herramienta initiate_return con la información proporcionada "
+        "para crear la devolución — NO pidas detalles adicionales al cliente. "
+        "Si también quiere un reembolso, haz handoff a agente_reembolsos después de iniciar la devolución. "
         "De lo contrario, haz handoff de vuelta a agente_triaje al terminar."
     ),
+    tools=[initiate_return],
 )
 
 refund_agent = Agent(
     client=client,
     name="agente_reembolsos",
     instructions=(
-        "Procesas reembolsos por artículos devueltos. Confirma los detalles del reembolso y avísale "
-        "al cliente cuándo puede esperar el dinero de vuelta. Haz handoff a agente_triaje al terminar."
+        "Procesas reembolsos por artículos devueltos. Usa la herramienta process_refund para emitir el reembolso "
+        "con la información ya proporcionada — NO pidas detalles adicionales al cliente. "
+        "Si el monto exacto no se conoce, usa una estimación razonable basada en el contexto. "
+        "Confirma el resultado y haz handoff a agente_triaje al terminar."
     ),
+    tools=[process_refund],
 )
 
 # ── Construye el workflow de handoff con reglas explícitas ─────────────────
@@ -108,7 +143,7 @@ workflow = (
         name="handoff_soporte_cliente",
         participants=[triage_agent, order_agent, return_agent, refund_agent],
         termination_condition=lambda conversation: (
-            len(conversation) > 0 and "goodbye" in conversation[-1].text.lower()
+            len(conversation) > 0 and "adiós" in conversation[-1].text.lower()
         ),
     )
     .with_start_agent(triage_agent)
@@ -126,14 +161,26 @@ workflow = (
 
 async def main() -> None:
     """Ejecuta un workflow de soporte con handoff y reglas explícitas de ruteo."""
-    request = "Quiero devolver una chamarra que compré la semana pasada y recibir un reembolso."
-    logger.info("Solicitud: %s\n", request)
+    request = (
+        "Quiero devolver una chamarra que compré la semana pasada y recibir un reembolso. "
+        "Pedido #12345, es una chamarra azul impermeable de senderismo, talla M, llegó con el cierre roto. "
+        "Pagué $89.99 y quiero el reembolso a mi tarjeta de crédito."
+    )
+    console.print(f"[bold]Solicitud:[/bold] {request}\n")
 
-    result = await workflow.run(request)
-    # El workflow de handoff devuelve la conversación completa como list[Message]
-    for output in result.get_outputs():
-        if isinstance(output, list):
-            print(output[-1].text)
+    current_agent = None
+
+    async for event in workflow.run(request, stream=True):
+        if event.type == "handoff_sent":
+            console.print(
+                f"\n🔀 [bold yellow]Handoff:[/bold yellow] {event.data.source} → {event.data.target}\n"
+            )
+
+        elif event.type == "output" and isinstance(event.data, AgentResponseUpdate):
+            if event.executor_id != current_agent:
+                current_agent = event.executor_id
+                console.print(f"\n🤖 [bold cyan]{current_agent}[/bold cyan]")
+            console.print(event.data.text, end="")
 
     if async_credential:
         await async_credential.close()

--- a/examples/spanish/workflow_magenticone.py
+++ b/examples/spanish/workflow_magenticone.py
@@ -116,6 +116,21 @@ def handle_stream_event(event: WorkflowEvent, last_message_id: str | None) -> st
         console.print(event.data, end="")
         return last_message_id
 
+    # Un participante terminó — muestra su salida
+    if event.type == "executor_completed" and isinstance(event.data, list) and event.data:
+        parts = [msg.text for msg in event.data if isinstance(msg, AgentResponseUpdate) and msg.text]
+        if parts:
+            full_text = "".join(parts)
+            console.print(
+                Panel(
+                    Markdown(full_text),
+                    title=f"🤖 {event.executor_id}",
+                    border_style="cyan",
+                    padding=(1, 2),
+                )
+            )
+        return last_message_id
+
     if event.type == "magentic_orchestrator":
         console.print()
         emoji = "✅" if event.data.event_type.name == "PROGRESS_LEDGER_UPDATED" else "🧭"

--- a/examples/workflow_handoffbuilder.py
+++ b/examples/workflow_handoffbuilder.py
@@ -25,12 +25,10 @@ from agent_framework.openai import OpenAIChatClient
 from agent_framework.orchestrations import HandoffBuilder
 from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
-from rich.logging import RichHandler
+from rich.console import Console
 
-log_handler = RichHandler(show_path=False, rich_tracebacks=True, show_level=False)
-logging.basicConfig(level=logging.WARNING, handlers=[log_handler], force=True, format="%(message)s")
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logging.basicConfig(level=logging.WARNING)
+console = Console()
 
 load_dotenv(override=True)
 API_HOST = os.getenv("API_HOST", "github")
@@ -135,19 +133,21 @@ async def main() -> None:
         # ── Run ───────────────────────────────────────────────────────────
 
         prompt = "Write a LinkedIn post about deploying Python agents on Azure Container Apps."
-        logger.info("Prompt: %s\n", prompt)
+        console.print(f"[bold]Prompt:[/bold] {prompt}\n")
 
         current_agent = None
 
         async for event in workflow.run(prompt, stream=True):
             if event.type == "handoff_sent":
-                logger.info("\n[Handoff] %s -> %s\n", event.data.source, event.data.target)
+                console.print(
+                    f"\n🔀 [bold yellow]Handoff:[/bold yellow] {event.data.source} → {event.data.target}\n"
+                )
 
             elif event.type == "output" and isinstance(event.data, AgentResponseUpdate):
                 if event.executor_id != current_agent:
                     current_agent = event.executor_id
-                    print(f"\n--- {current_agent} ---")
-                print(event.data.text, end="", flush=True)
+                    console.print(f"\n🤖 [bold cyan]{current_agent}[/bold cyan]")
+                console.print(event.data.text, end="")
 
     if async_credential:
         await async_credential.close()

--- a/examples/workflow_handoffbuilder_rules.py
+++ b/examples/workflow_handoffbuilder_rules.py
@@ -23,17 +23,17 @@ import logging
 import os
 import sys
 
-from agent_framework import Agent
+from pydantic import Field
+
+from agent_framework import Agent, AgentResponseUpdate, tool
 from agent_framework.openai import OpenAIChatClient
 from agent_framework.orchestrations import HandoffBuilder
 from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
-from rich.logging import RichHandler
+from rich.console import Console
 
-log_handler = RichHandler(show_path=False, rich_tracebacks=True, show_level=False)
-logging.basicConfig(level=logging.WARNING, handlers=[log_handler], force=True, format="%(message)s")
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logging.basicConfig(level=logging.WARNING)
+console = Console()
 
 load_dotenv(override=True)
 API_HOST = os.getenv("API_HOST", "github")
@@ -60,16 +60,46 @@ else:
     )
 
 
+# ── Tools ──────────────────────────────────────────────────────────────────
+
+
+@tool
+def initiate_return(
+    order_id: str = Field(description="The order ID to return"),
+    reason: str = Field(description="Reason for the return"),
+) -> str:
+    """Initiate a product return and generate a prepaid shipping label."""
+    return (
+        f"Return initiated for order {order_id} (reason: {reason}). "
+        f"Return label RL-{order_id}-2026 has been emailed to the customer. "
+        "Please drop off at any carrier location within 14 days."
+    )
+
+
+@tool
+def process_refund(
+    order_id: str = Field(description="The order ID to refund"),
+    amount: str = Field(description="Refund amount in USD"),
+) -> str:
+    """Process a refund to the customer's original payment method."""
+    return (
+        f"Refund of ${amount} for order {order_id} has been processed. "
+        "It will appear on the original payment method within 5-10 business days. "
+        f"Refund confirmation number: RF-{order_id}-2026."
+    )
+
+
 # ── Agents ─────────────────────────────────────────────────────────────────
 
 triage_agent = Agent(
     client=client,
     name="triage_agent",
     instructions=(
-        "You are a customer-support triage agent. Greet the customer, understand their issue, "
-        "and hand off to the right specialist: order_agent for order inquiries, "
+        "You are a customer-support triage agent. Briefly acknowledge the customer's issue "
+        "and immediately hand off to the right specialist: order_agent for order inquiries, "
         "return_agent for returns. You cannot handle refunds directly. "
-        "When the conversation is resolved, say 'Goodbye!' to end the session."
+        "Do NOT ask the customer for additional details — the specialist will handle it. "
+        "When the conversation is fully resolved (all agents have completed their tasks), say 'Goodbye!' to end the session."
     ),
 )
 
@@ -86,19 +116,24 @@ return_agent = Agent(
     client=client,
     name="return_agent",
     instructions=(
-        "You handle product returns. Help the customer initiate a return. "
-        "If they also want a refund, hand off to refund_agent. "
+        "You handle product returns. Use the initiate_return tool with the information provided "
+        "to create the return — do NOT ask the customer for extra details. "
+        "If they also want a refund, hand off to refund_agent after initiating the return. "
         "Otherwise, hand off back to triage_agent when done."
     ),
+    tools=[initiate_return],
 )
 
 refund_agent = Agent(
     client=client,
     name="refund_agent",
     instructions=(
-        "You process refunds for returned items. Confirm the refund details and let the "
-        "customer know when to expect the money back. Hand off to triage_agent when done."
+        "You process refunds for returned items. Use the process_refund tool to issue the refund "
+        "using the information already provided — do NOT ask the customer for extra details. "
+        "If the exact amount is unknown, use a reasonable estimate based on context. "
+        "Confirm the result and hand off to triage_agent when done."
     ),
+    tools=[process_refund],
 )
 
 # ── Build the handoff workflow with explicit routing rules ─────────────────
@@ -126,14 +161,26 @@ workflow = (
 
 async def main() -> None:
     """Run a customer support handoff workflow with explicit routing rules."""
-    request = "I want to return a jacket I bought last week and get a refund."
-    logger.info("Request: %s\n", request)
+    request = (
+        "I want to return a jacket I bought last week and get a refund. "
+        "Order #12345, it's a blue waterproof hiking jacket, size M, and it arrived with a torn zipper. "
+        "I paid $89.99 and I'd like the refund back to my credit card."
+    )
+    console.print(f"[bold]Request:[/bold] {request}\n")
 
-    result = await workflow.run(request)
-    # The handoff workflow outputs the full conversation as list[Message]
-    for output in result.get_outputs():
-        if isinstance(output, list):
-            print(output[-1].text)
+    current_agent = None
+
+    async for event in workflow.run(request, stream=True):
+        if event.type == "handoff_sent":
+            console.print(
+                f"\n🔀 [bold yellow]Handoff:[/bold yellow] {event.data.source} → {event.data.target}\n"
+            )
+
+        elif event.type == "output" and isinstance(event.data, AgentResponseUpdate):
+            if event.executor_id != current_agent:
+                current_agent = event.executor_id
+                console.print(f"\n🤖 [bold cyan]{current_agent}[/bold cyan]")
+            console.print(event.data.text, end="")
 
     if async_credential:
         await async_credential.close()

--- a/examples/workflow_magenticone.py
+++ b/examples/workflow_magenticone.py
@@ -106,6 +106,7 @@ magentic_workflow = MagenticBuilder(
 
 def handle_stream_event(event: WorkflowEvent, last_message_id: str | None) -> str | None:
     """Render a workflow stream event and return the updated message id."""
+    # Streaming token from an agent (may not fire for all orchestrators)
     if event.type == "output" and isinstance(event.data, AgentResponseUpdate):
         message_id = event.data.message_id
         if message_id != last_message_id:
@@ -116,6 +117,23 @@ def handle_stream_event(event: WorkflowEvent, last_message_id: str | None) -> st
         console.print(event.data, end="")
         return last_message_id
 
+    # A participant finished — show its output
+    if event.type == "executor_completed" and isinstance(event.data, list) and event.data:
+        # The data is a list of AgentResponseUpdate tokens — concatenate them
+        parts = [msg.text for msg in event.data if isinstance(msg, AgentResponseUpdate) and msg.text]
+        if parts:
+            full_text = "".join(parts)
+            console.print(
+                Panel(
+                    Markdown(full_text),
+                    title=f"🤖 {event.executor_id}",
+                    border_style="cyan",
+                    padding=(1, 2),
+                )
+            )
+        return last_message_id
+
+    # Orchestrator events (plan, progress ledger)
     if event.type == "magentic_orchestrator":
         console.print()
         emoji = "✅" if event.data.event_type.name == "PROGRESS_LEDGER_UPDATED" else "🧭"


### PR DESCRIPTION
## Changes

### Handoff examples (`workflow_handoffbuilder.py`)
- Replaced `logger` + `RichHandler` with `rich.console.Console` for cleaner, consistent output
- Uses emoji-styled output: 🔀 for handoffs, 🤖 for agent headers, bold prompt label

### Handoff rules examples (`workflow_handoffbuilder_rules.py`)
- Switched from non-streaming `await workflow.run()` to streaming, so handoffs are visible as they happen
- Added `initiate_return` and `process_refund` tools so return/refund agents take action instead of just chatting
- Simplified agent instructions to avoid excessive info-gathering (agents no longer ask 10+ questions)
- Expanded sample prompt with full order details (item description, price, refund method)
- Spanish termination condition uses "adiós" instead of "goodbye"

### MagenticOne example (`workflow_magenticone.py`)
- Added handling for `executor_completed` events to display each participant agent's output (was previously silent)
- Agent responses shown in cyan panels with agent name

### Spanish translations
- All changes mirrored in `/examples/spanish/` counterparts