### PR TITLE
Fix pgvector query parameter type in Postgres hybrid search sample

### DIFF
--- a/examples/agent_knowledge_pg_rewrite.py
+++ b/examples/agent_knowledge_pg_rewrite.py
@@ -38,6 +38,7 @@ from typing import Any
 import psycopg
 from openai import OpenAI
 from pgvector.psycopg import register_vector
+from pgvector import Vector
 
 from agent_framework import Agent, AgentSession, BaseContextProvider, Message, SessionContext, SupportsAgentRun
 from agent_framework.openai import OpenAIChatClient
@@ -305,7 +306,7 @@ class PostgresQueryRewriteProvider(BaseContextProvider):
 
     def _search(self, query: str) -> list[dict]:
         """Run hybrid search (vector + full-text) and return matching products."""
-        query_embedding = get_embedding(query)
+        query_embedding = Vector(get_embedding(query))
 
         cursor = self.conn.execute(
             HYBRID_SEARCH_SQL,

--- a/examples/agent_knowledge_postgres.py
+++ b/examples/agent_knowledge_postgres.py
@@ -34,6 +34,7 @@ from typing import Any
 import psycopg
 from openai import OpenAI
 from pgvector.psycopg import register_vector
+from pgvector import Vector
 
 from agent_framework import Agent, AgentSession, BaseContextProvider, Message, SessionContext, SupportsAgentRun
 from agent_framework.openai import OpenAIChatClient
@@ -257,7 +258,7 @@ class PostgresKnowledgeProvider(BaseContextProvider):
 
     def _search(self, query: str) -> list[dict]:
         """Run hybrid search (vector + full-text) and return matching products."""
-        query_embedding = get_embedding(query)
+        query_embedding = Vector(get_embedding(query))
 
         cursor = self.conn.execute(
             HYBRID_SEARCH_SQL,


### PR DESCRIPTION
## Purpose
* Fix a runtime error in `examples/agent_knowledge_postgres.py` and `examples/agent_knowledge_pg_rewrite.py` when running hybrid search against PostgreSQL with pgvector.
* Ensure the query embedding is passed as a `pgvector.Vector` instead of a plain Python list, so PostgreSQL can apply the pgvector `<=>` distance operator correctly.
* Prevent the sample from failing with `psycopg.errors.UndefinedFunction: operator does not exist: vector <=> double precision[]`.

## Does this introduce a breaking change?
[ ] Yes
[x] No


## Pull Request Type
What kind of change does this Pull Request introduce?

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:


## How to Test
* Get the code

```bash
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
Verify that the following are valid

The sample no longer fails with operator does not exist: vector <=> double precision[].
The hybrid search query runs successfully against the embedding vector column.
The sample still returns product results for example queries after the fix.
No other sample behavior changes beyond correcting the pgvector parameter type.

# Other Information
The root cause was that get_embedding(query) returned a Python list, which psycopg sent as double precision[].
pgvector’s <=> operator expects a vector, so the fix wraps the embedding with Vector(...) before executing the SQL query.
